### PR TITLE
Fix O3 build

### DIFF
--- a/media/libstagefright/Android.mk
+++ b/media/libstagefright/Android.mk
@@ -214,7 +214,7 @@ LOCAL_SHARED_LIBRARIES += \
         libstagefright_foundation \
         libdl
 
-LOCAL_CFLAGS += -Wno-multichar
+LOCAL_CFLAGS += -Os -Wno-multichar
 
 ifeq ($(DTS_CODEC_M_), true)
   LOCAL_SRC_FILES+= DTSUtils.cpp


### PR DESCRIPTION
Use Os for stagefright
* This is a workaround because using O3 here causes an ICE (Internal Compiler Error)